### PR TITLE
Fixed issues from telemetry

### DIFF
--- a/Dax.Template/Model/ModelChanges.cs
+++ b/Dax.Template/Model/ModelChanges.cs
@@ -214,7 +214,7 @@ namespace Dax.Template.Model
                 string columns = string.Join(
                     ",\r\n    ",
                     table.Columns.Where(c => c.Type != ColumnType.RowNumber).Select(column => $"\"'{PREVIEW_PREFIX}{varName}'[{column.Name}]\", [{column.Name}]"));
-                var renamedTableExpression = $"SELECTCOLUMNS (\r\n    {tableExpression},\r\n    {columns}\r\n)";
+                var renamedTableExpression = $"SELECTCOLUMNS (\r\n    {tableExpression}\r\n    ,\r\n    {columns}\r\n)";
                 return renamedTableExpression;
             }
 
@@ -360,7 +360,7 @@ namespace Dax.Template.Model
                     return result;
                 }));
                 var internalTableNames = previewQueryTables.Select(qt => qt.tableName).ToArray();
-                var previewQuery = $"SELECTCOLUMNS (\r\n    {RenameTableReferences(tableExpression, internalTableNames)},\r\n    {columns}\r\n)";
+                var previewQuery = $"SELECTCOLUMNS (\r\n    {RenameTableReferences(tableExpression, internalTableNames)}\r\n    ,\r\n    {columns}\r\n)";
                 string queryTablesDefinition = GetQueryTablesDefinition(model, previewQueryTables);
                 tableChanges.Preview = GetPreviewData(connection, previewQuery, previewRows, queryTablesDefinition);
             }

--- a/Dax.Template/Model/ModelChanges.cs
+++ b/Dax.Template/Model/ModelChanges.cs
@@ -213,7 +213,7 @@ namespace Dax.Template.Model
                 var table = model.Tables[tableName];
                 string columns = string.Join(
                     ",\r\n    ",
-                    table.Columns.Select(column => $"\"'{PREVIEW_PREFIX}{varName}'[{column.Name}]\", [{column.Name}]"));
+                    table.Columns.Where(c => c.Type != ColumnType.RowNumber).Select(column => $"\"'{PREVIEW_PREFIX}{varName}'[{column.Name}]\", [{column.Name}]"));
                 var renamedTableExpression = $"SELECTCOLUMNS (\r\n    {tableExpression},\r\n    {columns}\r\n)";
                 return renamedTableExpression;
             }

--- a/Dax.Template/Model/ModelChanges.cs
+++ b/Dax.Template/Model/ModelChanges.cs
@@ -347,10 +347,15 @@ namespace Dax.Template.Model
                         sourceColumn = $"[{sourceColumn}]";
                     }
                     sourceColumn = sourceColumn[sourceColumn.IndexOf('[')..];
-                    string columnExpression =
-                        (!string.IsNullOrWhiteSpace(calcColumn?.FormatString))
-                        ? $"FORMAT( {sourceColumn}, \"{calcColumn.FormatString}\" )"
-                        : sourceColumn;
+
+                    var columnExpression = sourceColumn;
+                    if (!string.IsNullOrWhiteSpace(calcColumn?.FormatString))
+                    {
+                        // Escape double quotes i.e. a user-defined format expression like "POSITIVE";"NEGATIVE";"ZERO" should be escaped to ""POSITIVE"";""NEGATIVE"";""ZERO""
+                        var escapedFormatString = calcColumn.FormatString.Replace("\"", "\"\"");
+                        columnExpression = $"FORMAT( {sourceColumn}, \"{escapedFormatString}\" )";
+                    }
+                    
                     string result = $"\"{column.Name}\", {columnExpression}";
                     return result;
                 }));


### PR DESCRIPTION
- Fix syntax error when invalid VAR names are generated for table names containing invalid characters (e.g. space)
- Excluded `ColumnType.RowNumber` from preview
- Escape double quotes in `FormatString`
- Fixed issue where commas can be commented out and generate a syntax error if the table expression ends with a comment