### PR TITLE
Fix escaping in table and names

### DIFF
--- a/src/Dax.Template/Extensions/StringExtensions.cs
+++ b/src/Dax.Template/Extensions/StringExtensions.cs
@@ -13,5 +13,10 @@
         {
             return current?.Equals(value, StringComparison.OrdinalIgnoreCase) ?? false;
         }
+
+        public static string? GetDaxTableName(this string? name)
+        {
+            return name?.Replace("'", "''");
+        }
     }
 }

--- a/src/Dax.Template/Extensions/StringExtensions.cs
+++ b/src/Dax.Template/Extensions/StringExtensions.cs
@@ -18,5 +18,10 @@
         {
             return name?.Replace("'", "''");
         }
+
+        public static string? GetDaxColumnName(this string? name)
+        {
+            return name?.Replace("]", "]]");
+        }
     }
 }

--- a/src/Dax.Template/Measures/MeasureTemplateBase.cs
+++ b/src/Dax.Template/Measures/MeasureTemplateBase.cs
@@ -8,6 +8,7 @@ using System.Text.RegularExpressions;
 using TabularModel = Microsoft.AnalysisServices.Tabular.Model;
 using TabularMeasure = Microsoft.AnalysisServices.Tabular.Measure;
 using System.Threading;
+using Dax.Template.Extensions;
 
 namespace Dax.Template.Measures
 {
@@ -299,14 +300,14 @@ namespace Dax.Template.Measures
         private static string? FindTablesList(TabularModel model, string attribute, string? value)
         {
             var tables = GetTablesFromAnnotations(model, attribute, value);
-            string result = string.Join(", ", tables.Select(t => $"'{t.Name}'"));
+            string result = string.Join(", ", tables.Select(t => $"'{t.Name.GetDaxTableName()}'"));
             return result;
         }
 
         private static string? FindColumnsList(TabularModel model, string attribute, string? value)
         {
             var columns = GetColumnsFromAnnotations(model, attribute, value);
-            string result = string.Join(", ", columns.Select(c => $"'{c.Table.Name}'[{c.Name}]"));
+            string result = string.Join(", ", columns.Select(c => $"'{c.Table.Name.GetDaxTableName()}'[{c.Name}]"));
             return result;
         }
 
@@ -321,7 +322,7 @@ namespace Dax.Template.Measures
             {
                 throw new AttributeNotFoundException(attribute, value);
             }
-            return $"'{tables.First().Name}'";
+            return $"'{tables.First().Name.GetDaxTableName()}'";
         }
 
         private static string? FindSingleColumn(TabularModel model, string attribute, string? value)
@@ -335,7 +336,7 @@ namespace Dax.Template.Measures
             {
                 throw new AttributeNotFoundException(attribute, value);
             }
-            return $"'{columns.First().Table.Name}'[{columns.First().Name}]";
+            return $"'{columns.First().Table.Name.GetDaxTableName()}'[{columns.First().Name}]";
         }
     }
 }

--- a/src/Dax.Template/Measures/MeasureTemplateBase.cs
+++ b/src/Dax.Template/Measures/MeasureTemplateBase.cs
@@ -307,7 +307,7 @@ namespace Dax.Template.Measures
         private static string? FindColumnsList(TabularModel model, string attribute, string? value)
         {
             var columns = GetColumnsFromAnnotations(model, attribute, value);
-            string result = string.Join(", ", columns.Select(c => $"'{c.Table.Name.GetDaxTableName()}'[{c.Name}]"));
+            string result = string.Join(", ", columns.Select(c => $"'{c.Table.Name.GetDaxTableName()}'[{c.Name.GetDaxColumnName()}]"));
             return result;
         }
 

--- a/src/Dax.Template/Measures/MeasuresTemplate.cs
+++ b/src/Dax.Template/Measures/MeasuresTemplate.cs
@@ -137,13 +137,13 @@ namespace Dax.Template.Measures
                 }
                 if (matchGetMinDates.Success)
                 {
-                    var listMin = string.Join(", ", scanColumns.Select(col => $"MIN ( '{col.Table.Name.GetDaxTableName()}'[{col.Name}] )"));
+                    var listMin = string.Join(", ", scanColumns.Select(col => $"MIN ( '{col.Table.Name.GetDaxTableName()}'[{col.Name.GetDaxColumnName()}] )"));
                     string replace = listMin.IsNullOrEmpty() ? "TODAY()" : $"MINX ( {{ {listMin} }}, ''[Value] )";
                     expression = regexGetMinDates.Replace(expression, replace);
                 }
                 if (matchGetMaxDates.Success)
                 {
-                    var listMax = string.Join(", ", scanColumns.Select(col => $"MAX ( '{col.Table.Name.GetDaxTableName()}'[{col.Name}] )"));
+                    var listMax = string.Join(", ", scanColumns.Select(col => $"MAX ( '{col.Table.Name.GetDaxTableName()}'[{col.Name.GetDaxColumnName()}] )"));
                     string replace = listMax.IsNullOrEmpty() ? "TODAY()" : $"MAXX ( {{ {listMax} }}, ''[Value] )";
                     expression = regexGetMaxDates.Replace(expression, replace);
                 }

--- a/src/Dax.Template/Measures/MeasuresTemplate.cs
+++ b/src/Dax.Template/Measures/MeasuresTemplate.cs
@@ -137,13 +137,13 @@ namespace Dax.Template.Measures
                 }
                 if (matchGetMinDates.Success)
                 {
-                    var listMin = string.Join(", ", scanColumns.Select(col => $"MIN ( '{col.Table.Name}'[{col.Name}] )"));
+                    var listMin = string.Join(", ", scanColumns.Select(col => $"MIN ( '{col.Table.Name.GetDaxTableName()}'[{col.Name}] )"));
                     string replace = listMin.IsNullOrEmpty() ? "TODAY()" : $"MINX ( {{ {listMin} }}, ''[Value] )";
                     expression = regexGetMinDates.Replace(expression, replace);
                 }
                 if (matchGetMaxDates.Success)
                 {
-                    var listMax = string.Join(", ", scanColumns.Select(col => $"MAX ( '{col.Table.Name}'[{col.Name}] )"));
+                    var listMax = string.Join(", ", scanColumns.Select(col => $"MAX ( '{col.Table.Name.GetDaxTableName()}'[{col.Name}] )"));
                     string replace = listMax.IsNullOrEmpty() ? "TODAY()" : $"MAXX ( {{ {listMax} }}, ''[Value] )";
                     expression = regexGetMaxDates.Replace(expression, replace);
                 }

--- a/src/Dax.Template/Model/ModelChanges.cs
+++ b/src/Dax.Template/Model/ModelChanges.cs
@@ -9,6 +9,7 @@ using TabularMeasure = Microsoft.AnalysisServices.Tabular.Measure;
 using TabularHierarchy = Microsoft.AnalysisServices.Tabular.Hierarchy;
 using System.Threading;
 using Dax.Template.Exceptions;
+using Dax.Template.Extensions;
 
 namespace Dax.Template.Model
 {
@@ -211,7 +212,7 @@ namespace Dax.Template.Model
                 var table = model.Tables[tableName];
                 string columns = string.Join(
                     ",\r\n    ",
-                    table.Columns.Where(c => c.Type != ColumnType.RowNumber).Select(column => $"\"'{PREVIEW_PREFIX}{varName}'[{column.Name}]\", [{column.Name}]"));
+                    table.Columns.Where(c => c.Type != ColumnType.RowNumber).Select(column => $"\"'{PREVIEW_PREFIX}{varName}'[{column.Name}]\", [{column.Name.GetDaxColumnName()}]"));
                 var renamedTableExpression = $"SELECTCOLUMNS (\r\n    {tableExpression}\r\n    ,\r\n    {columns}\r\n)";
                 return renamedTableExpression;
             }

--- a/src/Dax.Template/Tables/Dates/BaseDateTemplate.cs
+++ b/src/Dax.Template/Tables/Dates/BaseDateTemplate.cs
@@ -220,7 +220,7 @@ namespace Dax.Template.Tables.Dates
                     if (scanColumns != null)
                     {
                         // TODO: remove Table?.Name
-                        var listMin = string.Join(", ", scanColumns.Select(col => $"MIN ( '{col.Table?.Name}'[{col.Name}] )"));
+                        var listMin = string.Join(", ", scanColumns.Select(col => $"MIN ( '{col.Table?.Name.GetDaxTableName()}'[{col.Name}] )"));
                         replace = listMin.IsNullOrEmpty() ? "TODAY()" : $"MINX ( {{ {listMin} }}, ''[Value] )";
                     }
                     expression = regexGetMinDates.Replace(expression, replace);
@@ -236,7 +236,7 @@ namespace Dax.Template.Tables.Dates
                     if (scanColumns != null)
                     {
                         // TODO: remove Table?.Name
-                        var listMax = string.Join(", ", scanColumns.Select(col => $"MAX ( '{col.Table?.Name}'[{col.Name}] )"));
+                        var listMax = string.Join(", ", scanColumns.Select(col => $"MAX ( '{col.Table?.Name.GetDaxTableName()}'[{col.Name}] )"));
                         replace = listMax.IsNullOrEmpty() ? "TODAY()" : $"MAXX ( {{ {listMax} }}, ''[Value] )";
                     }
                     expression = regexGetMaxDates.Replace(expression, replace);
@@ -335,7 +335,7 @@ $@"
 
             if (string.IsNullOrEmpty(firstYear) && scanColumns != null)
             {
-                var listMin = string.Join(", ", scanColumns.Select(col => $"MIN ( '{col.Table.Name}'[{col.Name}] )"));
+                var listMin = string.Join(", ", scanColumns.Select(col => $"MIN ( '{col.Table.Name.GetDaxTableName()}'[{col.Name}] )"));
                 firstYear = listMin.IsNullOrEmpty() ? "YEAR ( TODAY() )" : $"YEAR ( MINX ( {{ {listMin} }}, ''[Value] ) )";
             }
             firstYear =
@@ -356,7 +356,7 @@ $@"
             if (string.IsNullOrEmpty(lastYear) && scanColumns != null)
             {
                 // TODO: remove Table?.Name
-                var listMax = string.Join(", ", scanColumns.Select(col => $"MAX ( '{col.Table?.Name}'[{col.Name}] )"));
+                var listMax = string.Join(", ", scanColumns.Select(col => $"MAX ( '{col.Table?.Name.GetDaxTableName()}'[{col.Name}] )"));
                 lastYear = listMax.IsNullOrEmpty() ? "YEAR ( TODAY() )" : $" YEAR ( MAXX ( {{ {listMax} }}, ''[Value] ) )";
             }
             lastYear =

--- a/src/Dax.Template/Tables/Dates/BaseDateTemplate.cs
+++ b/src/Dax.Template/Tables/Dates/BaseDateTemplate.cs
@@ -220,7 +220,7 @@ namespace Dax.Template.Tables.Dates
                     if (scanColumns != null)
                     {
                         // TODO: remove Table?.Name
-                        var listMin = string.Join(", ", scanColumns.Select(col => $"MIN ( '{col.Table?.Name.GetDaxTableName()}'[{col.Name}] )"));
+                        var listMin = string.Join(", ", scanColumns.Select(col => $"MIN ( '{col.Table?.Name.GetDaxTableName()}'[{col.Name.GetDaxColumnName()}] )"));
                         replace = listMin.IsNullOrEmpty() ? "TODAY()" : $"MINX ( {{ {listMin} }}, ''[Value] )";
                     }
                     expression = regexGetMinDates.Replace(expression, replace);
@@ -236,7 +236,7 @@ namespace Dax.Template.Tables.Dates
                     if (scanColumns != null)
                     {
                         // TODO: remove Table?.Name
-                        var listMax = string.Join(", ", scanColumns.Select(col => $"MAX ( '{col.Table?.Name.GetDaxTableName()}'[{col.Name}] )"));
+                        var listMax = string.Join(", ", scanColumns.Select(col => $"MAX ( '{col.Table?.Name.GetDaxTableName()}'[{col.Name.GetDaxColumnName()}] )"));
                         replace = listMax.IsNullOrEmpty() ? "TODAY()" : $"MAXX ( {{ {listMax} }}, ''[Value] )";
                     }
                     expression = regexGetMaxDates.Replace(expression, replace);
@@ -335,7 +335,7 @@ $@"
 
             if (string.IsNullOrEmpty(firstYear) && scanColumns != null)
             {
-                var listMin = string.Join(", ", scanColumns.Select(col => $"MIN ( '{col.Table.Name.GetDaxTableName()}'[{col.Name}] )"));
+                var listMin = string.Join(", ", scanColumns.Select(col => $"MIN ( '{col.Table.Name.GetDaxTableName()}'[{col.Name.GetDaxColumnName()}] )"));
                 firstYear = listMin.IsNullOrEmpty() ? "YEAR ( TODAY() )" : $"YEAR ( MINX ( {{ {listMin} }}, ''[Value] ) )";
             }
             firstYear =
@@ -356,7 +356,7 @@ $@"
             if (string.IsNullOrEmpty(lastYear) && scanColumns != null)
             {
                 // TODO: remove Table?.Name
-                var listMax = string.Join(", ", scanColumns.Select(col => $"MAX ( '{col.Table?.Name.GetDaxTableName()}'[{col.Name}] )"));
+                var listMax = string.Join(", ", scanColumns.Select(col => $"MAX ( '{col.Table?.Name.GetDaxTableName()}'[{col.Name.GetDaxColumnName()}] )"));
                 lastYear = listMax.IsNullOrEmpty() ? "YEAR ( TODAY() )" : $" YEAR ( MAXX ( {{ {listMax} }}, ''[Value] ) )";
             }
             lastYear =


### PR DESCRIPTION
Escape single quotes in table names : `'John's Table'[Column]` -> `'John''s Table'[Column]`
Escape square bracket in column names : `'Sales'[[Ship]Quantity]` -> `'Sales'[[Ship]]Quantity]`