### PR TITLE
Enable embedded debug symbols

### DIFF
--- a/src/Dax.Template/Dax.Template.csproj
+++ b/src/Dax.Template/Dax.Template.csproj
@@ -31,8 +31,9 @@
     <RepositoryUrl>https://github.com/sql-bi/DaxTemplate</RepositoryUrl>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
-    <IncludeSymbols>true</IncludeSymbols>
-    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>embedded</DebugType>
+    <IncludeSymbols>false</IncludeSymbols>
     <Deterministic>true</Deterministic>
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
   </PropertyGroup>


### PR DESCRIPTION
Allows file paths and line numbers to be included in stack traces. This helps troubleshoot errors when we get issues reported from exceptions such as this https://github.com/sql-bi/Bravo/issues/753#issuecomment-1839139313