### PR TITLE
Fix missing `]` escape in time intelligence measure expressions

### DIFF
--- a/src/Dax.Template/Measures/MeasureTemplateBase.cs
+++ b/src/Dax.Template/Measures/MeasureTemplateBase.cs
@@ -256,7 +256,7 @@ namespace Dax.Template.Measures
                         string.IsNullOrWhiteSpace(templateName)
                         ? originalMeasureName
                         : Template.GetTargetMeasureName(templateName, originalMeasureName);
-                    return $"[{replaceMeasureName}]";
+                    return $"[{replaceMeasureName.Replace("]", "]]")}]";
                 });
             }
             else


### PR DESCRIPTION
Fix an issue that generates an invalid time intelligence expression when the base measure name contains a `]` character.