### PR TITLE
Fix error when 0 (Sunday) is used as `WeekDayNumber` in HolidaysDefinition.json

### DIFF
--- a/src/Dax.Template/Tables/Dates/HolidaysTable.cs
+++ b/src/Dax.Template/Tables/Dates/HolidaysTable.cs
@@ -129,7 +129,7 @@ VAR __GeneratedRawWithDuplicatesUnfiltered =
                     __SeptemberEquinox + '{config.HolidaysDefinitionTable}'[DayNumber],
                 IF ( '{config.HolidaysDefinitionTable}'[MonthNumber] = 96, -- March Equinox
                     __MarchEquinox + '{config.HolidaysDefinitionTable}'[DayNumber],
-                IF ( '{config.HolidaysDefinitionTable}'[WeekDayNumber] <> 0,
+                IF ( '{config.HolidaysDefinitionTable}'[WeekDayNumber] IN {{ 0, 1, 2, 3, 4, 5, 6 }},
                     VAR _ReferenceDate =
                         DATE ( __HolidayYear, 1
                             + MOD ( '{config.HolidaysDefinitionTable}'[MonthNumber] - 1 + IF ( '{config.HolidaysDefinitionTable}'[OffsetWeek] < 0, 1 ), 12 ), 1 )

--- a/src/Dax.Template/Tables/Dates/HolidaysTable.cs
+++ b/src/Dax.Template/Tables/Dates/HolidaysTable.cs
@@ -129,7 +129,10 @@ VAR __GeneratedRawWithDuplicatesUnfiltered =
                     __SeptemberEquinox + '{config.HolidaysDefinitionTable}'[DayNumber],
                 IF ( '{config.HolidaysDefinitionTable}'[MonthNumber] = 96, -- March Equinox
                     __MarchEquinox + '{config.HolidaysDefinitionTable}'[DayNumber],
-                IF ( '{config.HolidaysDefinitionTable}'[WeekDayNumber] IN {{ 0, 1, 2, 3, 4, 5, 6 }},
+                IF ( '{config.HolidaysDefinitionTable}'[WeekDayNumber] IN {{ 0, 1, 2, 3, 4, 5, 6 }}
+                    && '{config.HolidaysDefinitionTable}'[DayNumber] = 0
+                    && '{config.HolidaysDefinitionTable}'[OffsetWeek] <> 0
+                    && '{config.HolidaysDefinitionTable}'[MonthNumber] IN {{ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 }},
                     VAR _ReferenceDate =
                         DATE ( __HolidayYear, 1
                             + MOD ( '{config.HolidaysDefinitionTable}'[MonthNumber] - 1 + IF ( '{config.HolidaysDefinitionTable}'[OffsetWeek] < 0, 1 ), 12 ), 1 )


### PR DESCRIPTION
Fixes a `Wrong configuration in HolidaysDefinition` error when 0 (Sunday) is used as `WeekDayNumber` in HolidaysDefinition.json.
This error has been reported in https://github.com/sql-bi/Bravo/issues/766

This error happens, for example, for Mother's Day holiday celebrated in the United States on the second Sunday in May.

```json
{
  "IsoCountry": "US",
  "MonthNumber": 5,
  "DayNumber": 0,
  "WeekDayNumber": 0,
  "OffsetWeek": 2,
  "OffsetDays": 0,
  "HolidayName": "Mother's Day",
  "SubstituteHoliday": "NoSubstituteHoliday",
  "ConflictPriority": 100
},
```
