### PR TITLE
Fix SubstituteHoliday to match WorkingDays range [2..6]

### DIFF
--- a/src/Dax.Template/Tables/Dates/HolidaysTable.cs
+++ b/src/Dax.Template/Tables/Dates/HolidaysTable.cs
@@ -152,15 +152,15 @@ VAR __GeneratedRawWithDuplicatesUnfiltered =
                 ERROR ( ""Wrong configuration in {config.HolidaysDefinitionTable}"" )
             ) ) ) ) ) ) )
 //            )
-        VAR __HolidayDay = WEEKDAY ( __HolidayDate, 1 ) - 1
+        VAR __HolidayDay = WEEKDAY ( __HolidayDate, 1 )
         VAR __SubstituteHolidayOffset = 
 //            SWITCH (
 //                TRUE,
                 IF ( '{config.HolidaysDefinitionTable}'[SubstituteHoliday] = -1,
                     SWITCH ( 
                         __HolidayDay, 
-                        0, 1,       -- If it falls on a Sunday then it is observed on Monday
-                        6, -1,      -- If it falls on a Saturday then it is observed on Friday
+                        1, 1,       -- If it falls on a Sunday then it is observed on Monday
+                        7, -1,      -- If it falls on a Saturday then it is observed on Friday
                         0
                     ),
                 IF ( '{config.HolidaysDefinitionTable}'[SubstituteHoliday] > 0
@@ -259,7 +259,7 @@ VAR __GeneratedSubstitutesOffset =
             VAR _SubstituteOffsetStep1 = [@SubstituteHolidayOffset] + _ConflictDay0 + _ConflictDay1 + _ConflictDay2
             VAR _HolidayDateStep1 = _CurrentHolidayDate + _SubstituteOffsetStep1
             VAR _HolidayDayStep1 =
-                WEEKDAY ( _HolidayDateStep1, 1 ) - 1
+                WEEKDAY ( _HolidayDateStep1, 1 )
             VAR _SubstituteHolidayOffsetNonWorkingDays =
                 IF (
                     NOT CONTAINS ( __WorkingDays, ''[Value], _HolidayDayStep1 ),
@@ -274,7 +274,7 @@ VAR __GeneratedSubstitutesOffset =
                             MINX ( __WorkingDays, ''[Value] ) + 7,
                             _NextWorkingDayStep2
                         )
-                    RETURN _SubstituteDay - _HolidayDateStep1
+                    RETURN _SubstituteDay - _HolidayDayStep1
                 )
             VAR _SubstituteOffsetStep2 = _SubstituteOffsetStep1 + _SubstituteHolidayOffsetNonWorkingDays
             VAR _SubstituteDateStep2 = _OriginalSubstituteDate + _SubstituteOffsetStep2


### PR DESCRIPTION
Fixes an issue where the calculated substitute holiday day is incorrect when `FridayIfSaturdayOrMondayIfSunday (-1)` is used.
Repro: year `2022` or `2023`, config `{ "US", 12, 25, 0, 0, 0, "Christmas Day", -1, 100, 0, 0 }`

This patch aims for preserving backward compatibility instead of breaking the current configuration value `{ 2, 3, 4, 5, 6 }`, which is used in multiple date templates.

A change to the documentation is also required here: https://docs.sqlbi.com/dax-template/configuration/config-object/holidays#workingdays to update the statement "The weekdays are expressed by integer numbers where Sunday is 0" where Sunday should be 1 instead of 0.