### PR TITLE
Fix date format string to ignore per-user Windows regional overrides

### DIFF
--- a/src/Dax.Template/Tables/Dates/BaseDateTemplate.cs
+++ b/src/Dax.Template/Tables/Dates/BaseDateTemplate.cs
@@ -27,8 +27,11 @@ public abstract class BaseDateTemplate<T> : CustomTableTemplate<T> where T : IDa
     protected override string? GetDefaultFormatString(Dax.Template.Model.Column column, Microsoft.AnalysisServices.Tabular.Model model)
     {
         string isoCulture = string.IsNullOrWhiteSpace(IsoFormat) ? model.Culture : IsoFormat;
+        // useUserOverride: false - a template must produce the same DAX/TOM output regardless of the
+        // machine's personal Windows regional-format overrides (Control Panel > Region), which
+        // `new CultureInfo(name)` otherwise applies by default even for a fully-qualified culture name.
         return (column.DataType == DataType.DateTime)
-            ? new CultureInfo(isoCulture).DateTimeFormat.ShortDatePattern.Replace('M', 'm')
+            ? new CultureInfo(isoCulture, useUserOverride: false).DateTimeFormat.ShortDatePattern.Replace('M', 'm')
             : null;
     }
 


### PR DESCRIPTION
BaseDateTemplate.GetDefaultFormatString built the default DateTime formatString via new CultureInfo(isoCulture).DateTimeFormat.ShortDatePattern. That constructor defaults to useUserOverride: true, so on a machine where the Windows user has customized Control Panel > Region short-date format (even under a plain "en-US" locale), the emitted formatString silently changes with it - e.g. "yyyy-mm-dd" instead of the culture-defined "m/d/yyyy".  This made generated templates non-reproducible across machines and was the actual cause of the StandardConfig_OfflineApply_MatchesSnapshot and CalendarStandardConfig_MatchesSnapshot golden-file failures. Pass useUserOverride: false so the format string depends only on the configured culture, not on the building machine's personal preferences.